### PR TITLE
Prevent undefined capture when there is no match.

### DIFF
--- a/lib/named-regexp.js
+++ b/lib/named-regexp.js
@@ -27,6 +27,7 @@ function named (regexp) {
 			if (!captures[name]) captures[name] = [];
 			if (matched[i + 1]) {
 				captures[name].push(matched[i + 1]);
+				matched.group = name;
 			}
 		}
 		matched.captures = captures;

--- a/lib/named-regexp.js
+++ b/lib/named-regexp.js
@@ -25,7 +25,9 @@ function named (regexp) {
 		for (var i = 0, len = names.length; i < len; i++) {
 			var name = names[i];
 			if (!captures[name]) captures[name] = [];
-			captures[name].push(matched[i + 1]);
+			if (matched[i + 1]) {
+				captures[name].push(matched[i + 1]);
+			}
 		}
 		matched.captures = captures;
 		matched.capture = function (name) {

--- a/test/test.js
+++ b/test/test.js
@@ -18,3 +18,8 @@ var replaced = re.replace('aaa bbb ccc ddd eee fff ggg', function (matched) {
 
 assert.strictEqual(replaced, 'ccc fff ggg');
 
+var re2 = named(/(:<foo2>[a-z]+)|(:<bar2>[0-9]+)/g);
+var matched2 = re2.exec('abc');
+
+assert.equal(matched2.captures.foo2.length, 1);
+assert.equal(matched2.captures.bar2.length, 0);


### PR DESCRIPTION
See the following code:

```
var regex = named(/(:<foo2>[a-z]+)|(:<bar2>[0-9]+)/g);
var matched = regex.exec('abc');
```

That code produces the following `matched` object:

```
[ 'abc',
  'abc',
  undefined,
  index: 0,
  input: 'abc',
  captures: { foo2: [ 'abc' ], bar2: [ undefined ] },
  capture: [Function] ]
```

With my change, that output becomes:

```
[ 'abc',
  'abc',
  undefined,
  index: 0,
  input: 'abc',
  captures: { foo2: [ 'abc' ], bar2: [] },
  capture: [Function] ]
```

notice `matched.captures.bar2` changes from `undefined` to empty.
