### PR TITLE
Added String support

### DIFF
--- a/lib/named-regexp.js
+++ b/lib/named-regexp.js
@@ -8,15 +8,17 @@
  *
  * This function does not used with normal captures.
  */
-function named (regexp) {
+function named (regexp, flags) {
 	var names = [];
-	var ret = new RegExp(regexp.source.replace(/\(:<(\w+)>/g, function (_, name) {
+    var isStringRegexp = typeof regexp == 'string'; 
+	var ret = new RegExp((isStringRegexp ? regexp : regexp.source).replace(/\(:<(\w+)>/g, function (_, name) {
 			names.push(name);
 			return '(';
 		}),
-		(regexp.global     ? 'g' : '') +
-		(regexp.ignoreCase ? 'i' : '') +
-		(regexp.multiline  ? 'm' : '')
+        (isStringRegexp ? flags :
+        (regexp.global     ? 'g' : '') +
+        (regexp.ignoreCase ? 'i' : '') +
+        (regexp.multiline  ? 'm' : ''))
 	);
 
 	var captures = function (matched) {
@@ -54,4 +56,3 @@ function named (regexp) {
 }
 
 this.named = named;
-


### PR DESCRIPTION
Allows named Regexp to take a string regex to coincide with the
RegExp object. Useful when wanting to repeat regex multiple times or do
string manipulation.
